### PR TITLE
Make users explicitly assign region for this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Creates the following resources:
 module "acm_cert" {
   source = "../../modules/aws-acm-cert"
 
+  region           = "us-west-2"
   alb_listener_arn = "arn:aws:elasticloadbalancing:us-west-2:..."
   domain_name      = "www.example.com"
   zone_name        = "example.com"
@@ -28,6 +29,7 @@ module "acm_cert" {
 | caa\_records | Add CAA records to route53. | list | `[]` | no |
 | domain\_name | Domain name to associate with the ACM certificate. | string | n/a | yes |
 | environment | Environment tag. | string | n/a | yes |
+| region | Region where the AWS ACM Certificate will be created. | string | n/a | yes |
 | zone\_name | The Route53 zone name for which the certificate should be verified and issued. | string | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@
  * module "acm_cert" {
  *   source = "../../modules/aws-acm-cert"
  *
+ *   region           = "us-west-2"
  *   alb_listener_arn = "arn:aws:elasticloadbalancing:us-west-2:..."
  *   domain_name      = "www.example.com"
  *   zone_name        = "example.com"

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  version = "~> 2.10.0"
+  region  = "${var.region}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "Region where the AWS ACM Certificate will be created."
+  type        = "string"
+}
+
 variable "alb_listener_arn" {
   type        = "string"
   description = "(Optional) Associate ACM certificate to and ALB listener."


### PR DESCRIPTION
I want to add a certificate in us-east-1 so I can use it with a Cloudfront distribution. However, most of my other resources are in us-west-2. This is my approach to place that certificate in the right place but it's a breaking change to the module. Is there a better way to handle this?