### PR TITLE
Fixes to support terraform-docs 0.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-fc7b4b9561a166e9039dc3fdf3a8ce3b734c815c
+      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
     steps:
       - checkout
       - restore_cache:

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "no-inline-html": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.21.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.24.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.21.0
+    rev: v1.23.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -27,15 +27,21 @@ module "acm_cert" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alb\_listener\_arn | \(Optional\) Associate ACM certificate to and ALB listener. | string | `""` | no |
-| caa\_records | Add CAA records to route53. | list(string) | `[]` | no |
-| domain\_name | Domain name to associate with the ACM certificate. | string | n/a | yes |
-| environment | Environment tag. e.g. prod | string | n/a | yes |
-| zone\_name | The Route53 zone name for which the certificate should be verified and issued. | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| alb\_listener\_arn | (Optional) Associate ACM certificate to and ALB listener. | `string` | `""` | no |
+| caa\_records | Add CAA records to route53. | `list(string)` | `[]` | no |
+| domain\_name | Domain name to associate with the ACM certificate. | `string` | n/a | yes |
+| environment | Environment tag. e.g. prod | `string` | n/a | yes |
+| zone\_name | The Route53 zone name for which the certificate should be verified and issued. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,3 @@
-/**
- * Creates a TLS certificate using AWS ACM for domains hosted on Route53.
- * The ACM certificate can also be attached to an ALB listener.
- *
- * Creates the following resources:
- *
- * * ACM certificate
- * * Route53 record used to validate TLS certificate
- * * Optional association with an ALB listener
- *
- * ## Usage
- *
- * ```hcl
- * module "acm_cert" {
- *   source = "../../modules/aws-acm-cert"
- *
- *   alb_listener_arn = "arn:aws:elasticloadbalancing:us-west-2:..."
- *   domain_name      = "www.example.com"
- *   zone_name        = "example.com"
- * }
- * ```
- */
-
 data "aws_route53_zone" "main" {
   name = var.zone_name
 }


### PR DESCRIPTION
terraform-docs 0.8 will dump some inline HTML in the readme for object variable, so I've removed the rule from the markdownlint config. I've also removed the redundant documentation in main.tf since that's now maintained in the README directly.