### PR TITLE
add create_before_destroy lifecycle hook for aws_acm_certificate resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,10 @@ resource "aws_acm_certificate" "main" {
     Environment = "${var.environment}"
     Automation  = "Terraform"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "main" {


### PR DESCRIPTION
- this prevents issues caused when trying to modify an `aws_acm_certificate` already in use (https://github.com/terraform-providers/terraform-provider-aws/issues/4712) and ensures the new certificate is created before terraform tries to delete the old certificate
- as per recommendation here: https://github.com/antonbabenko/terraform-provider-aws/commit/f862f94505439d439eb2fd1814b3b53ae63e116a : "It's recommended to specify `create_before_destroy = true` in a lifecycle block to replace a certificate
which is currently in use (eg, by [`aws_lb_listener`](lb_listener.html))."
