### PR TITLE
add create_before_destroy lifecycle hook for aws_acm_certificate resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,10 @@ resource "aws_acm_certificate" "main" {
     Environment = var.environment
     Automation  = "Terraform"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "main" {


### PR DESCRIPTION
* making same changes to master / terraform v12:

* this prevents issues caused when trying to modify an aws_acm_certificate already in use (terraform-providers/terraform-provider-aws#4712) and ensures the new certificate is created before terraform tries to delete the old certificate
* as per recommendation here: antonbabenko/terraform-provider-aws@f862f94 : "It's recommended to specify create_before_destroy = true in a lifecycle block to replace a certificate
which is currently in use (eg, by aws_lb_listener)."