### PR TITLE
Add an input for the caller to set the tags on the created ACM resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+      image: trussworks/circleci:b0e222f15769ec9d0bb8e4c637fab0d01c8636b0
     steps:
     - checkout
     - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -13,18 +13,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.31.1
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.72.1
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.46.2
     hooks:
       - id: golangci-lint
         args: [--timeout=3m]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+---
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: check-json
@@ -11,18 +12,18 @@ repos:
           - --autofix
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
+  - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.26.0
     hooks:
       - id: markdownlint
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
-  - repo: git://github.com/golangci/golangci-lint
+  - repo: https://github.com/golangci/golangci-lint
     rev: v1.33.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -32,31 +32,45 @@ module "acm_cert" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
+| [aws_lb_listener_certificate.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
+| [aws_route53_record.caa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alb\_listener\_arn | (Optional) Associate ACM certificate to and ALB listener. | `string` | `""` | no |
-| caa\_records | Add CAA records to route53. | `list(string)` | `[]` | no |
-| domain\_name | Domain name to associate with the ACM certificate. | `string` | n/a | yes |
-| environment | Environment tag. e.g. prod | `string` | n/a | yes |
-| zone\_name | The Route53 zone name for which the certificate should be verified and issued. | `string` | n/a | yes |
+| <a name="input_alb_listener_arn"></a> [alb\_listener\_arn](#input\_alb\_listener\_arn) | (Optional) Associate ACM certificate to and ALB listener. | `string` | `""` | no |
+| <a name="input_caa_records"></a> [caa\_records](#input\_caa\_records) | Add CAA records to route53. | `list(string)` | `[]` | no |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name to associate with the ACM certificate. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag. e.g. prod | `string` | n/a | yes |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The Route53 zone name for which the certificate should be verified and issued. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| acm\_arn | The ARN of the validated ACM certificate. |
-
+| <a name="output_acm_arn"></a> [acm\_arn](#output\_acm\_arn) | The ARN of the validated ACM certificate. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Developer Setup

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ No modules.
 | <a name="input_caa_records"></a> [caa\_records](#input\_caa\_records) | Add CAA records to route53. | `list(string)` | `[]` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name to associate with the ACM certificate. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment tag. e.g. prod | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be attached to the ACM certificate. | `list(string)` | `[]` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The Route53 zone name for which the certificate should be verified and issued. | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ No modules.
 | <a name="input_caa_records"></a> [caa\_records](#input\_caa\_records) | Add CAA records to route53. | `list(string)` | `[]` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name to associate with the ACM certificate. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment tag. e.g. prod | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be attached to the ACM certificate. | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be attached to the ACM certificate. | `map(string)` | `{}` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The Route53 zone name for which the certificate should be verified and issued. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -6,11 +6,7 @@ resource "aws_acm_certificate" "main" {
   domain_name       = var.domain_name
   validation_method = "DNS"
 
-  tags = {
-    Name        = var.domain_name
-    Environment = var.environment
-    Automation  = "Terraform"
-  }
+  tags = var.tags
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,8 @@ variable "caa_records" {
   default     = []
 }
 
+variable "tags" {
+  description = "Tags to be attached to the ACM certificate."
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,6 @@ variable "caa_records" {
 
 variable "tags" {
   description = "Tags to be attached to the ACM certificate."
-  type        = list(string)
-  default     = []
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
The AWS provider for terraform now supports `default_tags` on an `aws_acm_certificate`.  We are leveraging this functionality by setting `Automation = "Terraform"` as a default tag in the AWS provider. Since this module also has the `Automation` tag hard-coded, terraform plans may show that the tag is being added on each pass, although the resource is already tagged correctly:

```hcl
Terraform will perform the following actions:

  # module.acm_cert.aws_acm_certificate.main will be updated in-place
  ~ resource "aws_acm_certificate" "main" {
        id                        = "arn:aws:acm:us-east-1:REDACTED:certificate/REDACTED"
      ~ tags                      = {
          + "Automation"  = "Terraform"
            # (2 unchanged elements hidden)
        }
        # (8 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Additionally, hard-coding resource tags inhibits the module caller from applying their own tagging schema. :lock: [Slack discussion thread](https://trussworks.slack.com/archives/CLNC1MUBS/p1655156046540699)

This change addresses these issues by using an input to set the tags on the certificate.