### PR TITLE
"ci: validate-tf instead of validate and TFDocs GHA"

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: validate
+name: validate-tf
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  validate:
-    uses: trussworks/shared-actions/.github/workflows/validate.yml@main
+  validate-tf:
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
     with:
       go-version: 1.19

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         exclude: README.m(ark)?d(own)?
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.33.0
     hooks:
       - id: markdownlint
 
@@ -34,10 +34,13 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "v0.16.0"
     hooks:
-      - id: terraform_docs
-        args:
-          - --args=--config=.terraform-docs.yml
+      - id: terraform-docs-go
+        args: ["markdown", "table", "--output-file", "README.md", "."]
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.1
+    hooks:
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module "acm_cert" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -64,7 +64,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | acm\_arn | The ARN of the validated ACM certificate. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## Developer Setup
 


### PR DESCRIPTION
# [Update terraform module template to use terraform-docs' own hook](https://trello.com/c/0eThuK02/241-update-terraform-module-template-to-use-terraform-docs-own-hook)
# [Update terraform modules to use new validate-tf shared action](https://trello.com/c/i1sHKDjQ/243-update-terraform-modules-to-use-new-validate-tf-shared-action)

- ci: validate-tf instead of validate
- ci: terraform docs official action

