### PR TITLE
feed a zone_id instead of a zone_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ No modules.
 | [aws_lb_listener_certificate.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
 | [aws_route53_record.caa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
@@ -57,7 +56,7 @@ No modules.
 | domain\_name | Domain name to associate with the ACM certificate. | `string` | n/a | yes |
 | environment | Environment tag. e.g. prod | `string` | n/a | yes |
 | tags | Tags to be attached to the ACM certificate. | `map(string)` | `{}` | no |
-| zone\_name | The Route53 zone name for which the certificate should be verified and issued. | `string` | n/a | yes |
+| zone\_id | The Route53 zone id for which the certificate should be verified and issued. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-data "aws_route53_zone" "main" {
-  name = var.zone_name
-}
-
 resource "aws_acm_certificate" "main" {
   domain_name       = var.domain_name
   validation_method = "DNS"
@@ -21,7 +17,7 @@ resource "aws_route53_record" "main" {
       type   = dvo.resource_record_type
     }
   }
-  zone_id = data.aws_route53_zone.main.id
+  zone_id = var.zone_id
   ttl     = "60"
   name    = each.value.name
   type    = each.value.type
@@ -45,7 +41,7 @@ resource "aws_lb_listener_certificate" "main" {
 # https://docs.aws.amazon.com/acm/latest/userguide/troubleshooting-caa.html
 resource "aws_route53_record" "caa" {
   count   = length(var.caa_records) > 0 ? 1 : 0
-  zone_id = data.aws_route53_zone.main.id
+  zone_id = var.zone_id
   name    = var.domain_name
   type    = "CAA"
   records = var.caa_records

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,9 @@ variable "environment" {
   description = "Environment tag. e.g. prod"
 }
 
-variable "zone_name" {
+variable "zone_id" {
   type        = string
-  description = "The Route53 zone name for which the certificate should be verified and issued."
+  description = "The Route53 zone id for which the certificate should be verified and issued."
 }
 
 variable "caa_records" {


### PR DESCRIPTION
Removes the data element and changes the variable to have a user directly feed a zone_id to avoid terraform dependency issues